### PR TITLE
Remove prebuilts/clang directory from inputs for links

### DIFF
--- a/src/main/cc/proxy_client/proxy_client.cc
+++ b/src/main/cc/proxy_client/proxy_client.cc
@@ -427,7 +427,6 @@ int ComputeInputs(int argc, char** argv, const char** env, const string& cwd, co
   } else if (is_link) {
     use_args_inputs = true;
     inputs->insert("prebuilts/gcc");
-    inputs->insert("prebuilts/clang");
     FindAllFilesFromCommand(argc, argv, inputs);
     FindLibraryInputs(argc, argv, inputs);
   } else if (FLAGS_force_remote) {


### PR DESCRIPTION
Tested with AP@7 build as well, this directory is not needed for links.