### PR TITLE
Changes to make Android 9 build work

### DIFF
--- a/src/main/cc/proxy_client/proxy_client.cc
+++ b/src/main/cc/proxy_client/proxy_client.cc
@@ -455,11 +455,6 @@ int ComputeInputs(int argc, char** argv, const char** env, const string& cwd, co
     inputs->insert(argv[argc-1]);  // For Android compile commands, the compiled file is last.
   } // Linker commands need special treatment as well.
 
-  if (is_assembler) {
-    // For now disable assemble compiles and just run them locally since they
-    // fail on AP@9 builds.
-    *is_compile = false;
-  }
   return 0;
 }
 


### PR DESCRIPTION
Running an A9 build to make sure disabling assembly actions does not regress build times.

Changes:
1. Search for files in the compile command itself (for example blacklist.txt files)
2. Disable assembly compiles on RBE.