### PR TITLE
Generate static binary for use in CI

### DIFF
--- a/src/main/cc/proxy_client/BUILD
+++ b/src/main/cc/proxy_client/BUILD
@@ -20,12 +20,20 @@ cc_library(
         "//src/main/proto:include_processor_cc_proto",
         "@com_google_absl//absl/strings",
     ],
+    linkstatic = True,
+    features = [
+        "fully_static_link",
+    ],
 )
 
 cc_binary(
     name = "proxy_client",
     srcs = ["proxy_client_main.cc"],
     deps = [":proxy_client_lib"],
+    linkstatic = True,
+    features = [
+        "fully_static_link",
+    ],
 )
 
 cc_binary(


### PR DESCRIPTION
We need to generate a static binary since we cannot get the version of dynamic libstdc++ we need on CI machines.

Static binary is 11MB (versus 8MB for dynamic binary) and so invoking 1000 instances of this doesn't make us go OOM.